### PR TITLE
Use the `esp_hal_common::Pin`'s `number()` method instead of hard coding

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -113,10 +113,10 @@ checksum = "649c91bc01e8b1eac09fb91e8dbc7d517684ca6be8ebc75bb9cafc894f9fdb6f"
 dependencies = [
  "fnv",
  "ident_case",
- "proc-macro2 1.0.39",
- "quote 1.0.18",
+ "proc-macro2 1.0.40",
+ "quote 1.0.20",
  "strsim",
- "syn 1.0.96",
+ "syn 1.0.98",
 ]
 
 [[package]]
@@ -126,8 +126,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ddfc69c5bfcbd2fc09a0f38451d2daf0e372e367986a83906d1b0dbc88134fb5"
 dependencies = [
  "darling_core",
- "quote 1.0.18",
- "syn 1.0.96",
+ "quote 1.0.20",
+ "syn 1.0.98",
 ]
 
 [[package]]
@@ -171,7 +171,7 @@ dependencies = [
 [[package]]
 name = "esp-hal-common"
 version = "0.1.0"
-source = "git+https://github.com/esp-rs/esp-hal.git#86f4d0278269cb8abe8443b05776a79f70e3e886"
+source = "git+https://github.com/esp-rs/esp-hal.git#54be1b328daa27797292da5a097adebeb68f6c8a"
 dependencies = [
  "cfg-if",
  "embedded-hal 0.2.7",
@@ -189,24 +189,24 @@ dependencies = [
 [[package]]
 name = "esp-hal-procmacros"
 version = "0.1.0"
-source = "git+https://github.com/esp-rs/esp-hal.git#86f4d0278269cb8abe8443b05776a79f70e3e886"
+source = "git+https://github.com/esp-rs/esp-hal.git#54be1b328daa27797292da5a097adebeb68f6c8a"
 dependencies = [
  "darling",
  "proc-macro-error",
- "proc-macro2 1.0.39",
- "quote 1.0.18",
- "syn 1.0.96",
+ "proc-macro2 1.0.40",
+ "quote 1.0.20",
+ "syn 1.0.98",
 ]
 
 [[package]]
 name = "esp-println"
 version = "0.1.0"
-source = "git+https://github.com/esp-rs/esp-println#b61e72b6d800747ce04ca2837d37541b3651f469"
+source = "git+https://github.com/esp-rs/esp-println#a605103e4e614a921d4186d0146480b24ec83e46"
 
 [[package]]
 name = "esp32c3"
 version = "0.4.0"
-source = "git+https://github.com/esp-rs/esp-pacs.git?branch=with_source#06f316aa183b4324ce6f11ef7de822aab02ab476"
+source = "git+https://github.com/esp-rs/esp-pacs.git?branch=with_source#4bd860222534d4b0bee2db92290b6d30bca6d273"
 dependencies = [
  "bare-metal 1.0.0",
  "riscv 0.8.0",
@@ -217,17 +217,15 @@ dependencies = [
 [[package]]
 name = "esp32c3-hal"
 version = "0.1.0"
-source = "git+https://github.com/esp-rs/esp-hal.git#86f4d0278269cb8abe8443b05776a79f70e3e886"
+source = "git+https://github.com/esp-rs/esp-hal.git#54be1b328daa27797292da5a097adebeb68f6c8a"
 dependencies = [
  "bare-metal 1.0.0",
  "embedded-hal 0.2.7",
+ "embedded-hal 1.0.0-alpha.8",
  "esp-hal-common",
- "fugit",
- "nb 1.0.0",
  "r0",
  "riscv 0.8.0",
  "riscv-rt",
- "void",
 ]
 
 [[package]]
@@ -238,9 +236,9 @@ checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
 name = "fugit"
-version = "0.3.5"
+version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6d8595783d5ca52f0e9830036b3d24f359fae0fcc6bb5fde41f2dd82997cb58"
+checksum = "7ab17bb279def6720d058cb6c052249938e7f99260ab534879281a95367a87e5"
 dependencies = [
  "gcd",
 ]
@@ -287,9 +285,9 @@ version = "0.3.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "33c1e13800337f4d4d7a316bf45a567dbcb6ffe087f16424852d97e97a91f512"
 dependencies = [
- "proc-macro2 1.0.39",
- "quote 1.0.18",
- "syn 1.0.96",
+ "proc-macro2 1.0.40",
+ "quote 1.0.20",
+ "syn 1.0.98",
 ]
 
 [[package]]
@@ -354,9 +352,9 @@ dependencies = [
 
 [[package]]
 name = "heapless"
-version = "0.7.13"
+version = "0.7.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a08e755adbc0ad283725b29f4a4883deee15336f372d5f61fae59efec40f983"
+checksum = "065681e99f9ef7e0e813702a0326aedbcbbde7db5e55f097aedd1bf50b9dca43"
 dependencies = [
  "atomic-polyfill",
  "hash32",
@@ -433,9 +431,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "da25490ff9892aab3fcf7c36f08cfb902dd3e71ca0f9f9517bea02a73a5ce38c"
 dependencies = [
  "proc-macro-error-attr",
- "proc-macro2 1.0.39",
- "quote 1.0.18",
- "syn 1.0.96",
+ "proc-macro2 1.0.40",
+ "quote 1.0.20",
+ "syn 1.0.98",
  "version_check",
 ]
 
@@ -445,8 +443,8 @@ version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a1be40180e52ecc98ad80b184934baf3d0d29f979574e439af5a55274b35f869"
 dependencies = [
- "proc-macro2 1.0.39",
- "quote 1.0.18",
+ "proc-macro2 1.0.40",
+ "quote 1.0.20",
  "version_check",
 ]
 
@@ -461,9 +459,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.39"
+version = "1.0.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c54b25569025b7fc9651de43004ae593a75ad88543b17178aa5e1b9c4f15f56f"
+checksum = "dd96a1e8ed2596c337f8eae5f24924ec83f5ad5ab21ea8e455d3566c69fbcaf7"
 dependencies = [
  "unicode-ident",
 ]
@@ -479,11 +477,11 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.18"
+version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1feb54ed693b93a84e14094943b84b7c4eae204c512b7ccb95ab0c66d278ad1"
+checksum = "3bcdf212e9776fbcb2d23ab029360416bb1706b1aea2d1a5ba002727cbcab804"
 dependencies = [
- "proc-macro2 1.0.39",
+ "proc-macro2 1.0.40",
 ]
 
 [[package]]
@@ -535,9 +533,9 @@ checksum = "49b3de9ec5dc0a3417da371aab17d729997c15010e7fd24ff707773a33bddb64"
 
 [[package]]
 name = "rgb"
-version = "0.8.32"
+version = "0.8.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e74fdc210d8f24a7dbfedc13b04ba5764f5232754ccebfdf5fff1bad791ccbc6"
+checksum = "c3b221de559e4a29df3b957eec92bc0de6bc8eaf6ca9cfed43e5e1d67ff65a34"
 dependencies = [
  "bytemuck",
 ]
@@ -697,20 +695,20 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "1.0.96"
+version = "1.0.98"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0748dd251e24453cb8717f0354206b91557e4ec8703673a4b30208f2abaf1ebf"
+checksum = "c50aef8a904de4c23c788f104b7dddc7d6f79c647c7c8ce4cc8f73eb0ca773dd"
 dependencies = [
- "proc-macro2 1.0.39",
- "quote 1.0.18",
+ "proc-macro2 1.0.40",
+ "quote 1.0.20",
  "unicode-ident",
 ]
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.0"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d22af068fba1eb5edcb4aea19d382b2a3deb4c8f9d475c589b6ada9e0fd493ee"
+checksum = "5bd2fe26506023ed7b5e1e315add59d6f584c621d037f9368fea9cfb988f368c"
 
 [[package]]
 name = "unicode-xid"

--- a/src/async_hal.rs
+++ b/src/async_hal.rs
@@ -1,9 +1,6 @@
 use core::task::{Context, Poll, Waker};
 
-use esp32c3_hal::ehal::digital::v2::InputPin;
-use esp32c3_hal::interrupt;
-use esp32c3_hal::Cpu;
-use esp_println::println;
+use esp32c3_hal::{ehal::digital::v2::InputPin, interrupt, Cpu};
 use heapless::FnvIndexMap;
 
 #[derive(Debug, Clone)]
@@ -25,10 +22,10 @@ where
 
 impl<P> AsyncPin<P>
 where
-    P: InputPin,
+    P: InputPin + esp_hal_common::Pin,
 {
     // we should have a function to know the pin number
-    pub fn from_pin(pin: P, number: u8) -> AsyncPin<P> {
+    pub fn from_pin(pin: P) -> AsyncPin<P> {
         interrupt::enable(
             Cpu::ProCpu,
             esp32c3_hal::pac::Interrupt::GPIO,
@@ -44,6 +41,8 @@ where
             interrupt::CpuInterrupt::Interrupt3,
             interrupt::Priority::Priority1,
         );
+
+        let number = pin.number();
 
         AsyncPin { pin, number }
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -34,6 +34,7 @@ async fn async_main() {
     let peripherals = Peripherals::take().unwrap();
     let system = peripherals.SYSTEM.split();
     let _clocks = ClockControl::boot_defaults(system.clock_control).freeze();
+
     let mut rtc_cntl = RtcCntl::new(peripherals.RTC_CNTL);
     let mut timer0 = Timer::new(peripherals.TIMG0);
     let mut timer1 = Timer::new(peripherals.TIMG1);
@@ -46,13 +47,10 @@ async fn async_main() {
     let io = IO::new(peripherals.GPIO, peripherals.IO_MUX);
 
     let boot_button = io.pins.gpio9.into_pull_down_input();
-    let boot_button = AsyncPin::from_pin(boot_button, 9);
-    //handle_boot_button(boot_button).await;
+    let boot_button = AsyncPin::from_pin(boot_button);
 
     let io1_button = io.pins.gpio1.into_pull_down_input();
-    let io1_button = AsyncPin::from_pin(io1_button, 1);
-
-    //handle_second_button(io1_button).await;
+    let io1_button = AsyncPin::from_pin(io1_button);
 
     futures::join!(
         handle_boot_button(boot_button),


### PR DESCRIPTION
I've updated the `esp_hal_common::Pin` trait to have a `number()` method which just returns a `u8`. This allows us to use this method instead of having to hard code the pin number when creating the async wrapper.